### PR TITLE
Update fxa id location

### DIFF
--- a/assets/iframe.html
+++ b/assets/iframe.html
@@ -8,16 +8,23 @@
     <div id="content"></div>
 
     <script id="sub-template" type="text/x-handlebars-template">
-        <div>
+        {{#if error}}
+        <div><p>{{error}}</p></div>
+        {{else}}
+         <div>
             <p><b>User:</b> {{user}}</p>
-            {{#list subscriptions}}
-                <ul>
-                    <li><b>Subscription:</b> {{subscriptionName}}</li>
-                    <li><b>Status:</b> {{status}}</li>
-                    <li><b>Last Payment:</b> {{lastPaymentDate}}</li>
-                    <li><b>Next Payment:</b> {{nextPaymentDate}}</li>
-                </ul>
-            {{/list}}
+            {{#if subscriptions}}
+                {{#list subscriptions}}
+                    <ul>
+                        <li><b>Subscription:</b> {{subscriptionName}}</li>
+                        <li><b>Status:</b> {{status}}</li>
+                        <li><b>Last Payment:</b> {{lastPaymentDate}}</li>
+                        <li><b>Next Payment:</b> {{nextPaymentDate}}</li>
+                    </ul>
+                {{/list}}
+            {{else}}
+                <p>No subscriptions to display.</p>
+            {{/if}}
         </div>
         <br />
         <hr />
@@ -25,6 +32,11 @@
         <div>
             <iframe id="fxa-dashboard" src="{{dashboardSrc}}" height="100%"></iframe>
         </div>
+        {{/if}}
+    </script>
+
+    <script id="not-subscriber" type="text/x-handlebars-template">
+        <div><p>N{{errorText}}</p></div>
     </script>
 
     <script src="https://cdn.jsdelivr.net/jquery/3.2.1/jquery.min.js"></script>

--- a/assets/main.js
+++ b/assets/main.js
@@ -12,20 +12,12 @@ $(function () {
         client.get(ticketGroupProperty).then(function (data) {
             var ticketGroup = data[ticketGroupProperty];
 
-            console.log(ticketGroup);
-
-
             var regex = /subscription/ig;
             var found = ticketGroup.match(regex);
 
-            console.log(found);
             if (found) {
-                console.log(fxaProperty);
-
                 client.get(fxaProperty).then(function (data) {
                     var fxa_id = data[fxaProperty];
-
-                    console.log(fxa_id);
 
                     if (fxa_id) {
                         getSubscriptionInfo(client, fxa_id);
@@ -37,7 +29,7 @@ $(function () {
                 displayError('Not a Subscription Services ticket.')
             }
         }, function (error) {
-            console.log(error);
+            console.error(error);
         })
     })
 })
@@ -62,8 +54,6 @@ function getSubscriptionInfo(client, fxa_id) {
 
         client.request(settings).then(
             function(data) {
-                console.log(data);
-
                 var templateContent = {
                     'user': fxa_id,
                     'subscriptions': formatSubscriptions(data['subscriptions']),

--- a/manifest.json
+++ b/manifest.json
@@ -19,21 +19,20 @@
       "name": "apiBaseUrl",
       "type": "text",
       "required": true,
-      "secure": false,
-      "default": "https://71l44s00vg.execute-api.us-west-2.amazonaws.com/dev/v1"
+      "secure": false
     },
     {
       "name": "apiToken",
       "type": "text",
       "required": true,
-      "secure": true
+      "secure": false
     },
     {
       "name": "fxaFieldId",
       "type": "text",
       "required": true,
       "secure": false,
-      "default": "360018061392"
+      "default": "fxa_user_id"
     },
     {
       "name": "fxaDashboardUrl",

--- a/translations/en.json
+++ b/translations/en.json
@@ -9,8 +9,8 @@
       },
       "apiToken": { "label": "Token for SubHub API" },
       "fxaFieldId": {
-        "label": "Field ID for Firefox Account",
-        "helpText": "You can locate the Field ID by navigating to the Ticket Fields dashboard."
+        "label": "Field Key for Firefox Account",
+        "helpText": "You can locate the Field Key by navigating to the User Fields dashboard."
       },
       "fxaDashboardUrl" : {
         "label": "Base URL for FxA Dashboard.",


### PR DESCRIPTION
Updated code to access firefox id from the user object instead of the ticket object. Added checks to ensure that the module can/should be displayed with proper messaging in the cases where the module cannot be loaded.