### PR TITLE
Update main.js README.md en.json: Updated Subhub API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ load subscription data. Otherwise, the app will display any subscription data fo
 does not have any subscription data to display.
 
 ## Local Development
+
+Before beginning development, you will need to install Zendesk App Tools (ZAT). Installation instructions can be followed
+here: https://develop.zendesk.com/hc/en-us/articles/360001075048-Installing-and-using-the-Zendesk-apps-tools
+
 From within a terminal, you can run the app locally and test the app within the Zendesk instance.
 
 To start the application locally execute `zat server` from the application's root directory.

--- a/assets/main.js
+++ b/assets/main.js
@@ -47,7 +47,7 @@ function getSubscriptionInfo(client, user_id) {
         var apiToken = metadata.settings.apiToken;
 
         var settings = {
-            'url': baseUrl + '/support/' + user_id + '/subscriptions',
+            'url': baseUrl + '/v1/support/' + user_id + '/subscriptions',
             'type': 'GET',
             'content-Type': 'x-www-form-urlencoded',
             'dataType': 'json',
@@ -85,7 +85,7 @@ function formatSubscriptions(rawSubscriptions) {
 
     rawSubscriptions.forEach(function (obj) {
         var subscription = {
-            'subscriptionName': obj.nickname,
+            'subscriptionName': obj.plan_name,
             'status': obj.status,
             'lastPaymentDate': formatUnixTimestamp(obj.current_period_start),
             'nextPaymentDate': formatUnixTimestamp(obj.current_period_end)

--- a/translations/en.json
+++ b/translations/en.json
@@ -5,7 +5,7 @@
     "parameters": {
       "apiBaseUrl": {
         "label": "Base URL for SubHub API.",
-        "helpText": "Include up to the version and do not supply a trailing forward slash. Format: 'https://example.com/dev/v1'"
+        "helpText": "Include up to but not including the version and do not supply a trailing forward slash. Format: 'https://example.com/dev'"
       },
       "apiToken": { "label": "Token for SubHub API" },
       "userIdFieldKey": {


### PR DESCRIPTION
main.js: updated to store version for api in the application to ensure that any update to the desired subhub version will require re-assessment of the usage within the applicaiton
en.json: updated the help text for providing the subhub api base url to specify that the version number is not included
README.md: added information on getting ZAT installed prior to beginning local development